### PR TITLE
chore: migrate Renovate preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "prConcurrentLimit": 5,
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## Summary
- migrate Renovate from the deprecated `config:base` preset to `config:recommended`
- keep the existing `prConcurrentLimit` setting unchanged

## Context
The Dependency Dashboard currently reports **Config Migration Needed** for this repository. This is the minimal Renovate preset migration only.

## Testing
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`

Did not run `atmos test run` because the repo guidance says the Terratest suite deploys AWS resources and may incur cost.